### PR TITLE
add terms of use for demos

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
         | <a href="https://github.com/watson-developer-cloud">GitHub</a>
         | <a href="https://watson-api-explorer.mybluemix.net/">Swagger API Documentation</a>
         | <a href="https://console.ng.bluemix.net/catalog/?search=watson">Watson on Bluemix</a>
+        | <a href="/terms">Demo Terms of Use</a>
     </p>
 
     <h2>Java SDK</h2>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>IBM Watson Developer Cloud</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
+  </head>
+  <body>
+    <div class="container">
+      <!-- Banner -->
+      <div class="page-header">
+        <h1>IBM Watson Demo - Terms of Use</h1>
+      </div>
+
+      <!-- Top level nav -->
+      <p><a href="http://www.ibm.com/watson/developercloud/">Info</a>
+      | <a href="http://www.ibm.com/watson/developercloud/doc/">Documentation</a>
+      | <a href="https://github.com/watson-developer-cloud">GitHub</a>
+      | <a href="https://watson-api-explorer.mybluemix.net/">Swagger API Documentation</a>
+      | <a href="https://console.ng.bluemix.net/catalog/?search=watson">Watson on Bluemix</a>
+      | <a href="/index">Back Home</a>
+      </p>
+
+      <!-- Terms of Use -->
+
+      <div>
+        <p><span class="app-name"></span> Terms of Use</p>
+
+        <p>
+        <span>
+          This Agreement sets forth the terms governing your use of
+          the
+        </span>
+        <span class="app-name"></span>
+          <span>
+            application (“the Application”). By using the Application, you
+            agree to these Terms of Use; if you do not agree to these all of these
+            Terms of Use, do not use this Application.
+          </span>
+        </p>
+
+        <p>The Application is made available to you, as an individual person,
+        non-exclusively by International Business Machines Corporation (“IBM”) at
+        no charge via an Internet connection provided by you.</p>
+
+        <p>The Application and any related software, documentation, content or
+        other materials provided by IBM in connection with the Application are
+        owned by IBM or a third party supplier, and are copyrighted and licensed,
+        not sold. Transfer of your rights under this Agreement is not
+        permitted.</p>
+
+        <p>You are authorized to use the Application and associated content for
+        your own personal use for informational purposes only. The Application is
+        not intended to be used for productive or commercial purposes, and such
+        use is not permitted. </p>
+
+        <p>Your use of the Application is also subject to IBM’s Online
+        Application Privacy Statement https://www.ibm.com/privacy/us/en/</p>
+
+        <p>The Application may be unavailable during maintenance scheduled
+        determined by IBM, and other scheduled or non-scheduled downtimes may
+        occur. Either party may terminate use or access to the Application at any
+        time.</p>
+
+        <p>You are responsible for your use of the Application and associated
+        content and the results obtained from their use. You are also responsible
+        for any information, data or other materials (“User Materials”) that you
+        submit or provide in connection with the Application, including ensuring
+        that you have all necessary authorizations to permit IBM and its
+        subcontractors to use, host, cache, record, copy and display such User
+        Materials without charge. IBM has no responsibility for the User
+        Materials that you submit or provide in connection with the Application.
+        All User Materials which you submit or provide to the Application or to
+        IBM are non-confidential.</p>
+
+        <p>The Application source code is available for download under a separate
+        URL that contains associated license terms.</p>
+
+        <p>The Application and associated content are provided “AS IS”, with no
+        warranties, express or implied, including without limitation, warranties
+        of merchantability, fitness for a particular purpose, or
+        non-infringement. IBM and its affiliates and suppliers will not be
+        liable, under any contract, tort, strict liability, or other theory, for
+        any direct, special, punitive, indirect, incidental, or consequential
+        damages, including, but not limited to, loss of or damage to data, loss
+        of anticipated revenue, profits, savings, or goodwill, work stoppage or
+        impairment of other assets, whether or not foreseeable and whether or not
+        you have been advised of the possibility of such damages. You are
+        responsible for compliance with any applicable laws and regulations which
+        may govern your accessing and use of the Application.</p>
+
+        <p>It is IBM’s policy to respect the intellectual property rights of
+        others. To report the infringement of copyrighted material, please visit
+        the Digital Millennium Copyright Act Notices page at:
+        https://www.ibm.com/legal/us/en/dmca.html.</p>
+
+        <p>The laws of the State of New York, excluding its conflicts of laws
+        rules, govern this Agreement and your use of the Application.</p>
+
+        <p>IBM wants to know what you think about the Application and how IBM can
+        make them better. You can do this by providing your comments and feedback
+        via online forums or other submission vehicles which IBM makes available
+        to you. By providing your comments and feedback to IBM, you authorize IBM
+        to publish and display them and to use them in the development and
+        enhancement of its products and Application.</p>
+
+        <p>The foregoing is the complete agreement between you and IBM regarding
+        your use of the Application and replaces any prior communications related
+        to such use.</p>
+      </div>
+    </div>
+
+    <script>
+      var appName = (new URL(window.location)).searchParams.get('name');
+      var appNamePlaceholders = document.getElementsByClassName('app-name');
+      var appNamePlaceholdersArray = Array.from(appNamePlaceholders);
+
+      appNamePlaceholdersArray.forEach((el) => {
+        if (appName) {
+          appName = decodeURI(appName);
+        }
+
+        el.innerHTML = `<b>${appName || 'Demo Application'}</b>`;
+      });
+    </script>
+  </body>
+</html>

--- a/terms.html
+++ b/terms.html
@@ -34,11 +34,11 @@
           the
         </span>
         <span class="app-name"></span>
-          <span>
-            application (“the Application”). By using the Application, you
-            agree to these Terms of Use; if you do not agree to these all of these
-            Terms of Use, do not use this Application.
-          </span>
+        <span>
+          application (“the Application”). By using the Application, you
+          agree to these Terms of Use; if you do not agree to these all of these
+          Terms of Use, do not use this Application.
+        </span>
         </p>
 
         <p>The Application is made available to you, as an individual person,
@@ -117,12 +117,14 @@
       var appNamePlaceholders = document.getElementsByClassName('app-name');
       var appNamePlaceholdersArray = Array.from(appNamePlaceholders);
 
-      appNamePlaceholdersArray.forEach((el) => {
-        if (appName) {
-          appName = decodeURI(appName);
-        }
+      if (appName) {
+        appName = decodeURI(appName);
+      } else {
+        appName = 'Demo Application';
+      }
 
-        el.innerHTML = `<b>${appName || 'Demo Application'}</b>`;
+      appNamePlaceholdersArray.forEach((el) => {
+        el.innerHTML = `<b>${appName}</b>`;
       });
     </script>
   </body>


### PR DESCRIPTION
@germanattanasio this adds a standard terms of use page for the demos. It interpolates the name of the demo using the `?name=` query param.