### PR TITLE
Update link for Maven Central package search

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 
     <h2>Java SDK</h2>
     <ul>
-        <li><a href="http://search.maven.org/#search|ga|1|g%3A%22com.ibm.watson.developer_cloud%22%20a%3A%22java-sdk%22">Maven</a></li>
+        <li><a href="https://search.maven.org/search?q=g:com.ibm.watson%20a:ibm-watson">Maven</a></li>
         <li><a href="https://github.com/watson-developer-cloud/java-sdk">GitHub</a></li>
         <li><a href="http://watson-developer-cloud.github.io/java-sdk/">JavaDoc</a></li>
     </ul>


### PR DESCRIPTION
The old link pointing to the latest Java SDK package in Maven Central was still using the old package name from before we all switched over to `ibm-watson`.

This PR just updates that link to point to the correct location.